### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate, Llama2 CodeLlama (100+LLMs) [LiteLLM] 

### DIFF
--- a/llmzoo/eval/eval_gpt_review_all.py
+++ b/llmzoo/eval/eval_gpt_review_all.py
@@ -6,13 +6,14 @@ import re
 import backoff
 import numpy as np
 import openai
+import litellm
 import ray
 
 
 @ray.remote(num_cpus=4)
 @backoff.on_exception(backoff.expo, openai.error.RateLimitError)
 def get_eval(content: str, max_tokens: int):
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model='gpt-3.5-turbo',
         messages=[{
             'role': 'system',

--- a/llmzoo/eval/prompt_turbo.py
+++ b/llmzoo/eval/prompt_turbo.py
@@ -3,6 +3,7 @@ import json
 
 import backoff
 import openai
+import litellm
 import ray
 import shortuuid
 
@@ -12,7 +13,7 @@ MODEL_ID = 'gpt-3.5-turbo'
 @ray.remote(num_cpus=4)
 @backoff.on_exception(backoff.expo, openai.error.RateLimitError)
 def completions_with_backoff(**kwargs):
-    return openai.ChatCompletion.create(**kwargs)
+    return litellm.completion(**kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```